### PR TITLE
Add and configure sbt-wartremover

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,3 +18,6 @@ addSbtPlugin("com.geirsson"       % "sbt-scalafmt" % "1.6.0-RC3")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh"      % "0.3.3")
 
 scalafmtOnCompile := true
+
+// Wart remover settings
+wartremoverWarnings in (Compile, compile) ++= Warts.unsafe

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 libraryDependencies += { "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value }
 addSbtPlugin("com.geirsson"       % "sbt-scalafmt" % "1.6.0-RC3")
+addSbtPlugin("org.wartremover"    % "sbt-wartremover" % "2.2.1")

--- a/src/sbt-test/scalaz-sbt/wartremover/project/build.properties
+++ b/src/sbt-test/scalaz-sbt/wartremover/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.1.6

--- a/src/sbt-test/scalaz-sbt/wartremover/project/test.sbt
+++ b/src/sbt-test/scalaz-sbt/wartremover/project/test.sbt
@@ -1,0 +1,6 @@
+val pluginVersion =
+  sys.props
+    .get("plugin.version")
+    .getOrElse(sys.error("Sys prop plugin.version must be defined!"))
+
+addSbtPlugin("org.scalaz" % "scalaz-sbt" % pluginVersion)

--- a/src/sbt-test/scalaz-sbt/wartremover/src/main/scala/Test.scala
+++ b/src/sbt-test/scalaz-sbt/wartremover/src/main/scala/Test.scala
@@ -1,0 +1,3 @@
+object Test {
+  def foo(a: String, b: Int): String = b + a
+}

--- a/src/sbt-test/scalaz-sbt/wartremover/test
+++ b/src/sbt-test/scalaz-sbt/wartremover/test
@@ -1,0 +1,4 @@
+# Verify that the sbt-wartremover plugin is correctly activated
+
+> clean
+> compile

--- a/src/sbt-test/scalaz-sbt/wartremover/test.sbt
+++ b/src/sbt-test/scalaz-sbt/wartremover/test.sbt
@@ -1,0 +1,3 @@
+enablePlugins(ScalazPlugin)
+
+name := "wartremover"


### PR DESCRIPTION
fixes #15 

- turned on only the safe warts to just issue warnings instead of errors (Other Scalaz projects which uses the plugin will get affected if we throw error on compilation)