### PR TITLE
Add "Sonatype Snapshot" resolver

### DIFF
--- a/src/main/scala/Compilation.scala
+++ b/src/main/scala/Compilation.scala
@@ -21,6 +21,9 @@ object Compilation {
       "-Ywarn-unused:imports",
       "-Xfatal-warnings"
     ),
+    resolvers += Seq(
+      "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
+    ),
     libraryDependencies ++= compilerPlugins ++ Seq(
       "com.github.ghik" %% "silencer-lib" % silencerVersion % Provided,
       "org.scalacheck"  %% "scalacheck"   % "1.14.0"        % Test

--- a/src/main/scala/Compilation.scala
+++ b/src/main/scala/Compilation.scala
@@ -21,7 +21,7 @@ object Compilation {
       "-Ywarn-unused:imports",
       "-Xfatal-warnings"
     ),
-    resolvers += Seq(
+    resolvers ++= Seq(
       "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
     ),
     libraryDependencies ++= compilerPlugins ++ Seq(


### PR DESCRIPTION
I think that for internal scalaz dependencies we should use source-dependency as much as possible, grabbing the very last version of (the needed part of) the scalaz ecosystem each time we build our application.

Nonetheless, there are chances that projects using the plugin have some of their dependencies depend transitively on artefacts that are located exclusively in Sonatype's snapshots area. So we need to have the snapshots resolver activated to make sure that having this kind of dependency never breaks a build.

This is closely related to [this PR](https://github.com/scalaz/scalaz-schema/pull/11)
