### PR TITLE
Remove custom vertical alignment settings and run scalafmt on codebase

### DIFF
--- a/src/main/resources/scalafmt.conf
+++ b/src/main/resources/scalafmt.conf
@@ -21,14 +21,6 @@ spaces {
   inImportCurlyBraces = true
 }
 
-verticalMultiline {
-  atDefnSite = true
-  arityThreshold = 4
-  newlineAfterOpenParen = true
-  newlineAfterImplicitKW = true
-  newlineBeforeImplicitKW = false
-}
-
 rewrite.rules = [
   AsciiSortImports,
   AvoidInfix,

--- a/src/main/scala/Compilation.scala
+++ b/src/main/scala/Compilation.scala
@@ -21,7 +21,7 @@ object Compilation {
       "-Xfatal-warnings"
     ),
     resolvers ++= Seq(
-      "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
+      "Sonatype OSS Snapshots".at("https://oss.sonatype.org/content/repositories/snapshots")
     ),
     libraryDependencies ++= compilerPlugins ++ Seq(
       "com.github.ghik" %% "silencer-lib" % silencerVersion % Provided,


### PR DESCRIPTION
PR to remove custom vertical alignment settings

For justification, the existing rules routinely produce inconsistent or hard to read code.
e.g.
(seemingly arbitrary split onto next line)
```
def distinctBy[A: Type, B: Type](d: DataStream[A])(
        by: A =>: B): DataStream[A]
```
(pushing simple case class definitions onto multiple lines)
```
case class Compose(left: RowFunction, right: RowFunction)
        extends RowFunction
```
etc

The default settings for scalafmt `verticalMultiline` are as follows and they seem quite sensible, so I have removed the overrides entirely.
```
verticalMultiline.atDefnSite = false
verticalMultiline.arityThreshold = 100
verticalMultiline.newlineBeforeImplicitKW = false
verticalMultiline.newlineAfterImplicitKW = false
verticalMultiline.newlineAfterOpenParen = false
verticalMultiline.excludeDanglingParens = [
  class
  trait
]
```