### PR TITLE
Added "-Xsource:2.13" compiler option

### DIFF
--- a/src/main/scala/Compilation.scala
+++ b/src/main/scala/Compilation.scala
@@ -61,6 +61,7 @@ object Compilation {
     "-Xlint:private-shadow", // A private field (or class parameter) shadows a superclass field.
     "-Xlint:stars-align", // Pattern sequence wildcard must align with sequence component.
     "-Xlint:type-parameter-shadow", // A local type parameter shadows a type already in scope.
+    "-Xsource:2.13",
     "-Yrangepos",
     "-Ywarn-dead-code", // Warn when dead code is identified.
     "-Ywarn-extra-implicit", // Warn when more than one implicit parameter section is defined.


### PR DESCRIPTION
This flag is used by scalaz to support features provided by `pascal`.

For example it is required to compile the following code
```scala
  def test[A, F[_], G[_]](fa: F[A])(fg: F ~> G): G[A] =
    fg.apply(fa)
```